### PR TITLE
feat(api): jwt, drop Depends

### DIFF
--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "anyforce"
-version = "0.29.7"
+version = "0.29.8"
 description = ""
 authors = [
     {name = "exherb", email = "i@4leaf.me"},


### PR DESCRIPTION
Depends的使用需要级联，中间断了是不会处理，不知道理解对了没有，比如下图（修改之后的实现）：
- jwt的获取函数是基于Depends的，那么在使用上面应该作为调要者的Depends参数，否则自身Depends在使用上面会有问题。 如xapi场景，获取用户信息并未使用Depends，而是传入Request参数，所以就提议与session处理保持一致，传入参数处理
- 另外还有一个问题，Depends里面的异常抛出好像不大好处理，应为Depends往往作为参数或者默认值存在，而且是级联的。

![image](https://github.com/42signal/anyforce/assets/10124154/36af5f59-510d-49a4-929e-c9dea96e5add)
