### PR TITLE
fix(fields): SplitCharField default value type

### DIFF
--- a/runtime/anyforce/model/fields.py
+++ b/runtime/anyforce/model/fields.py
@@ -339,7 +339,7 @@ class SplitCharDBField(fields.CharField, List[str]):
         **kwargs: Any,
     ) -> None:
         self.separator = separator or "\n"
-        super().__init__(max_length, default=default, **kwargs)
+        super().__init__(max_length, default=None if default is None else self.separator.join(default), **kwargs)
 
     def to_python_value(
         self, value: Optional[Union[str, List[str]]]

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "anyforce"
-version = "0.40.3"
+version = "0.40.5"
 description = ""
 authors = [
     {name = "exherb", email = "i@4leaf.me"},


### PR DESCRIPTION
数据库字段的默认值应该是 `""` 或这 `null` 比较合适，当前只能设置为`[]`